### PR TITLE
hexNull: Fixed TP never sending invalid response

### DIFF
--- a/Assets/Modules/hexNull/Scripts/HexNullTPScript.cs
+++ b/Assets/Modules/hexNull/Scripts/HexNullTPScript.cs
@@ -41,9 +41,6 @@ public class HexNullTPScript : TPScript<HexNullScript>
             }
 
         }
-
-
-        yield return null;
     }
 
     public override IEnumerator TwitchHandleForcedSolve()


### PR DESCRIPTION
In Twitch Plays implementation, if you yield return anything, the command is considered valid. This pull request fixes the invalid response never being sent by removing the last lines which trigger every time, and therefore consider the command valid every time.

> The coroutine must yield return something to acknowledge that the command is valid. You can yield return anything as long as it's not one of the special sendtochat methods, which are explained near the bottom of this section. Most implementations simply yield return null. If nothing is yielded Twitch Plays will assume the command was invalid and tell the user.

Read more: https://github.com/samfundev/KtaneTwitchPlays/wiki/External-Mod-Module-Support#advanced-implementation